### PR TITLE
refactor(xml): rewrite XML parsing, unskip tests

### DIFF
--- a/src/xmlParser.spec.js
+++ b/src/xmlParser.spec.js
@@ -60,7 +60,8 @@ describe("xmlParser", () => {
       });
     });
 
-    test("parse multiple response documents", () => {
+    // TODO: unclear whether this scenario occurs
+    test.skip("parse multiple response documents", () => {
       const xml = `<?xml version="1.0" ?><data><response value="ACK"/></data>
                   <?xml version="1.0" ?><data><response value="DONE"/></data>`;
       const result = parser.getResponse(encoder.encode(xml));

--- a/src/xmlParser.spec.js
+++ b/src/xmlParser.spec.js
@@ -102,7 +102,7 @@ describe("xmlParser", () => {
       expect(result).toEqual(["Test message"]);
     });
 
-    test.skip("parse multiple logs", () => {
+    test("parse multiple logs", () => {
       const xml = `<?xml version="1.0" ?>
         <data>
           <log value="Message 1"/>
@@ -117,7 +117,7 @@ describe("xmlParser", () => {
       ]);
     });
 
-    test.skip("parse program operation logs", () => {
+    test("parse program operation logs", () => {
       const xml = `<?xml version="1.0" ?>
         <data>
           <log value="Writing sector 0x1000"/>
@@ -137,7 +137,7 @@ describe("xmlParser", () => {
       expect(result).toEqual(["Test & debug <sample>"]);
     });
 
-    test.skip("handle mixed response and log content", () => {
+    test("handle mixed response and log content", () => {
       const xml = `<?xml version="1.0" ?>
         <data>
           <response value="ACK" status="progress"/>
@@ -188,7 +188,7 @@ describe("xmlParser", () => {
       });
     });
 
-    test.skip("parse storage info response", () => {
+    test("parse storage info response", () => {
       const xml = `<?xml version="1.0" ?>
         <data>
           <response value="ACK"/>


### PR DESCRIPTION
- Rewrite the XML parser to iterate all "response" and "log" elements in the tree
- Removes splitting on `<?xml` tag/handling of multiple documents in one response (unclear yet whether this occurs in real scenarios)
- Removes handling of special byte sequence (also unclear when this occurs)
- Adds JSDoc type hints

I found [this code](https://git.codelinaro.org/linaro/qcomlt/qdl/-/blob/master/firehose.c) online for QDL/firehose and didn't see any handling for multiple documents in a response, or the string replace. bkerler/edl added the string replace in [this commit](https://github.com/bkerler/edl/commit/d81e8573798a85d9666203264be7fb4b3d2e339f#diff-0d216995b8feed49bb08c2091508f821157ac7b6f5dc00c97b484d4e16e9e88f) but there is no explanation attached.