### PR TITLE
fix(demo): disable minify due to bug in bun build

### DIFF
--- a/demo/build.ts
+++ b/demo/build.ts
@@ -2,7 +2,8 @@ const build = await Bun.build({
   entrypoints: ["./src/index.html"],
   outdir: "./dist",
   sourcemap: "linked",
-  minify: true,
+  // https://github.com/oven-sh/bun/issues/16335
+  // minify: true,
 });
 
 const outputs = build.outputs.map(({ path, kind, size }) => ({ path, kind, "size (KiB)": (size / 1024).toFixed(1) }));


### PR DESCRIPTION
Enabling minification causes elements to be stripped from the \<head\>, including our CSS.