### PR TITLE
fix(firehose): onProgress can be undefined

### DIFF
--- a/src/firehose.js
+++ b/src/firehose.js
@@ -260,7 +260,7 @@ export class Firehose {
       }
     }
 
-    onProgress(1.0);
+    onProgress?.(1.0);
     return true;
   }
 


### PR DESCRIPTION
why don't tsc or biome warn for this?