### PR TITLE
cleanup usbClass read/write implementation

### DIFF
--- a/src/firehose.js
+++ b/src/firehose.js
@@ -63,7 +63,7 @@ export class Firehose {
   async xmlSend(command, wait = true) {
     // FIXME: warn if command is shortened
     const dataToSend = new TextEncoder().encode(command).slice(0, this.cfg.MaxXMLSizeInBytes);
-    await this.cdc.write(dataToSend, null, wait);
+    await this.cdc.write(dataToSend, wait);
 
     let rData = new Uint8Array();
     let counter = 0;
@@ -231,7 +231,7 @@ export class Firehose {
             wdata = concatUint8Array([wdata, fillArray]);
           }
           await this.cdc.write(wdata);
-          await this.cdc.write(new Uint8Array(0), null, true);
+          await this.cdc.write(new Uint8Array(0), true);
           offset += wlen;
           bytesWritten += wlen;
           bytesToWriteSplit -= wlen;
@@ -239,7 +239,7 @@ export class Firehose {
           // Need this for sparse image when the data.length < MaxPayloadSizeToTargetInBytes
           // Add ~2.4s to total flash time
           if (sparseformat && bytesWritten < total) {
-            await this.cdc.write(new Uint8Array(0), null, true);
+            await this.cdc.write(new Uint8Array(0), true);
           }
 
           if (i % 10 === 0) {

--- a/src/sahara.js
+++ b/src/sahara.js
@@ -236,23 +236,22 @@ export class Sahara {
 
   async cmdDone() {
     const toSendData = packGenerator([cmd_t.SAHARA_DONE_REQ, 0x8]);
-    if (await this.cdc.write(toSendData)) {
-      let res = await this.getResponse();
-      if ("cmd" in res) {
-        let cmd = res.cmd;
-        if (cmd === cmd_t.SAHARA_DONE_RSP) {
-          return true;
-        } else if (cmd === cmd_t.SAHARA_END_TRANSFER) {
-          if ("data" in res) {
-            let pkt = res.data;
-            if (pkt.image_tx_status === status_t.SAHARA_NAK_INVALID_CMD) {
-              console.error("Invalid transfer command received");
-              return false;
-            }
+    await this.cdc.write(toSendData);
+    let res = await this.getResponse();
+    if ("cmd" in res) {
+      let cmd = res.cmd;
+      if (cmd === cmd_t.SAHARA_DONE_RSP) {
+        return true;
+      } else if (cmd === cmd_t.SAHARA_END_TRANSFER) {
+        if ("data" in res) {
+          let pkt = res.data;
+          if (pkt.image_tx_status === status_t.SAHARA_NAK_INVALID_CMD) {
+            console.error("Invalid transfer command received");
+            return false;
           }
-        } else {
-          throw "Sahara - Received invalid response";
         }
+      } else {
+        throw "Sahara - Received invalid response";
       }
     }
     return false;

--- a/src/sahara.js
+++ b/src/sahara.js
@@ -52,7 +52,7 @@ export class Sahara {
   async getResponse() {
     try {
       let data = await this.cdc.read();
-      let data_text = new TextDecoder('utf-8').decode(data.data);
+      let data_text = new TextDecoder('utf-8').decode(data);
       if (data.length === 0) {
         return {};
       } else if (data_text.includes("<?xml")) {

--- a/src/usblib.js
+++ b/src/usblib.js
@@ -104,13 +104,13 @@ export class usbClass {
       /** @type {Uint8Array<ArrayBuffer>[]} */
       const chunks = [];
       let received = 0;
-      while (received < length) {
+      do {
         const chunk = await this.read();
         if (chunk.byteLength) {
           chunks.push(chunk);
           received += chunk.byteLength;
         }
-      }
+      } while (received < length);
       return concatUint8Array(chunks);
     } else {
       const result = await this.device?.transferIn(this.epIn?.endpointNumber, this.maxSize);

--- a/src/usblib.js
+++ b/src/usblib.js
@@ -105,10 +105,10 @@ export class usbClass {
       const packets = [];
       let received = 0;
       while (received < length) {
-        const result = await this.device?.transferIn(this.epIn?.endpointNumber, Math.min(length - received, this.maxSize));
-        if (result.data?.byteLength) {
-          packets.push(new Uint8Array(result.data.buffer));
-          received += result.data.byteLength;
+        const packet = await this.read();
+        if (packet.byteLength) {
+          packets.push(packet);
+          received += packet.byteLength;
         } else {
           console.debug("[usblib] Received empty response");
         }
@@ -116,7 +116,7 @@ export class usbClass {
       return concatUint8Array(packets);
     } else {
       const result = await this.device?.transferIn(this.epIn?.endpointNumber, this.maxSize);
-      return new Uint8Array(result.data.buffer);
+      return new Uint8Array(result.data?.buffer);
     }
   }
 

--- a/src/usblib.js
+++ b/src/usblib.js
@@ -109,8 +109,6 @@ export class usbClass {
         if (chunk.byteLength) {
           chunks.push(chunk);
           received += chunk.byteLength;
-        } else {
-          console.debug("[usblib] Received empty response");
         }
       }
       return concatUint8Array(chunks);


### PR DESCRIPTION
- add missing JSDoc/type hints
- handle reading more data than `USBEndpoint.packetSize`
  - the current implementation has a bug causing it to always stop reading after the first response
- remove unused `pktSize` param to write
- remove unused return value from write
- cleanup duplicate code