### PR TITLE
lint: re-enable style lint rules

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -27,7 +27,13 @@
         "noUnnecessaryContinue": "off"
       },
       "style": {
-        "all": false
+        "noNonNullAssertion": "warn",
+        "noParameterAssign": "warn",
+        "noUnusedTemplateLiteral": "warn",
+        "noUselessElse": "warn",
+        "useConst": "warn",
+        "useSingleVarDeclarator": "off",
+        "useTemplate": "warn"
       },
       "suspicious": {
         "noExplicitAny": "off"


### PR DESCRIPTION
Re-enable rules to avoid introducing new bugs. Changes current errors to warnings.