### PR TITLE
firehose: generate XML using helper function

### DIFF
--- a/src/firehose.js
+++ b/src/firehose.js
@@ -103,7 +103,6 @@ export class Firehose {
    * @returns {Promise<boolean>}
    */
   async configure() {
-    // FIXME: is encoding="UTF-8" required?
     const connectCmd = toXml("configure", {
       MemoryName: this.cfg.MemoryName,
       Verbose: 0,

--- a/src/firehose.js
+++ b/src/firehose.js
@@ -1,6 +1,6 @@
 import * as Sparse from "./sparse"
 import { concatUint8Array, containsBytes, compareStringToBytes, sleep } from "./utils"
-import { xmlParser } from "./xmlParser"
+import { toXml, xmlParser } from "./xml.js"
 
 
 /**
@@ -207,11 +207,12 @@ export class Firehose {
       numPartitionSectors += 1;
     }
 
-    const data = `<?xml version="1.0" ?><data>\n` +
-              `<program SECTOR_SIZE_IN_BYTES="${this.cfg.SECTOR_SIZE_IN_BYTES}"` +
-              ` num_partition_sectors="${numPartitionSectors}"` +
-              ` physical_partition_number="${physicalPartitionNumber}"` +
-              ` start_sector="${startSector}" />\n</data>`;
+    const data = toXml("program", {
+      SECTOR_SIZE_IN_BYTES: this.cfg.SECTOR_SIZE_IN_BYTES,
+      num_physical_sectors: numPartitionSectors,
+      physical_partition_number: physicalPartitionNumber,
+      start_sector: startSector,
+    });
     let i = 0;
     let bytesWritten = 0;
     const rsp = await this.xmlSend(data);

--- a/src/firehose.js
+++ b/src/firehose.js
@@ -1,6 +1,6 @@
 import * as Sparse from "./sparse"
 import { concatUint8Array, containsBytes, compareStringToBytes, sleep } from "./utils"
-import { toXml, xmlParser } from "./xml.js"
+import { toXml, xmlParser } from "./xml"
 
 
 /**

--- a/src/firehose.js
+++ b/src/firehose.js
@@ -208,7 +208,7 @@ export class Firehose {
 
     const rsp = await this.xmlSend(toXml("program", {
       SECTOR_SIZE_IN_BYTES: this.cfg.SECTOR_SIZE_IN_BYTES,
-      num_physical_sectors: numPartitionSectors,
+      num_partition_sectors: numPartitionSectors,
       physical_partition_number: physicalPartitionNumber,
       start_sector: startSector,
     }));

--- a/src/xml.js
+++ b/src/xml.js
@@ -1,3 +1,13 @@
+/**
+ * @param {string} tagName
+ * @param {Record<string, any>} [attributes={}]
+ * @returns {string}
+ */
+export function toXml(tagName, attributes = {}) {
+  const attrs = Object.entries(attributes).map(([key, value]) => `${key}="${value}"`).join(" ");
+  return `<?xml version="1.0" ?><data><${tagName}${attrs ? ` ${attrs}` : ''} /></data>`;
+}
+
 export class xmlParser {
   decoder = new TextDecoder();
   parser = new DOMParser();

--- a/src/xml.spec.js
+++ b/src/xml.spec.js
@@ -1,6 +1,27 @@
 import { describe, expect, test } from "bun:test";
 
-import { xmlParser } from "./xmlParser";
+import { toXml, xmlParser } from "./xml.js";
+
+
+describe("toXml", () => {
+  test("strings", () => {
+    const expected = `<?xml version="1.0" ?><data><power value="reset" /></data>`;
+    expect(toXml("power", { value: "reset" })).toBe(expected);
+  });
+  test("numbers", () => {
+    const expected = `<?xml version="1.0" ?><data><program SECTOR_SIZE_IN_BYTES="4096" num_partition_sectors="500" physical_partition_number="0" start_sector="0" /></data>`;
+    expect(toXml("program", {
+      SECTOR_SIZE_IN_BYTES: 4096,
+      num_partition_sectors: 500,
+      physical_partition_number: 0,
+      start_sector: 0,
+    })).toBe(expected);
+  });
+  test("empty", () => {
+    const expected = `<?xml version="1.0" ?><data><empty /></data>`;
+    expect(toXml("empty")).toBe(expected);
+  });
+});
 
 
 describe("xmlParser", () => {

--- a/src/xml.spec.js
+++ b/src/xml.spec.js
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { toXml, xmlParser } from "./xml.js";
+import { toXml, xmlParser } from "./xml";
 
 
 describe("toXml", () => {


### PR DESCRIPTION
Replaces hardcoded XML strings with a new toXml helper function

- Updates all XML command generation to use the new helper
- Adds unit tests for the toXml function

Validation
- [x] tested demo still works :heavy_check_mark: 
- [x] tested flash works :heavy_check_mark: 