### PR TITLE
CI: test Sparse with system image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
       - name: download system image
         run: |
           url=$(curl https://raw.githubusercontent.com/commaai/openpilot/master/system/hardware/tici/agnos.json | jq -r ".[] | select(.name == \"system\") | .url")
-          wget -O system.img $url
+          curl -L $url | unxz > system.img
           simg2img system.img system-raw.img
 
       - name: run sparse benchmark

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
       - run: bun install
 
       - name: install sparse image tool
-        run: apt-get update && apt-get install -y simg2img
+        run: sudo apt-get update && sudo apt-get install -y simg2img
 
       - name: download system image
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,26 @@ jobs:
       - run: bun test
       - run: bun run build
 
+  benchmark:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v1
+      - run: bun install
+
+      - name: install sparse image tool
+        run: apt-get update && apt-get install -y simg2img
+
+      - name: download system image
+        run: |
+          url=$(curl https://raw.githubusercontent.com/commaai/openpilot/master/system/hardware/tici/agnos.json | jq -r ".[] | select(.name == \"system\") | .url")
+          wget -O system.img $url
+          simg2img system.img system-raw.img
+
+      - name: run sparse benchmark
+        run: bun scripts/sparse-benchmark.js system.img system-raw.img
+
   demo:
     runs-on: ubuntu-24.04
     timeout-minutes: 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
 
   benchmark:
     runs-on: ubuntu-24.04
-    timeout-minutes: 5
+    timeout-minutes: 3
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
 
   benchmark:
     runs-on: ubuntu-24.04
-    timeout-minutes: 3
+    timeout-minutes: 4
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,9 @@ jobs:
         run: |
           url=$(curl https://raw.githubusercontent.com/commaai/openpilot/master/system/hardware/tici/agnos.json | jq -r ".[] | select(.name == \"system\") | .url")
           curl -L $url | unxz > system.img
-          simg2img system.img system-raw.img
+
+      - name: generate raw system image
+        run: simg2img system.img system-raw.img
 
       - name: run sparse benchmark
         run: bun scripts/sparse-benchmark.js system.img system-raw.img

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,10 +37,24 @@ jobs:
       - name: install sparse image tool
         run: sudo apt-get update && sudo apt-get install -y android-sdk-libsparse-utils
 
-      - name: download system image
+      - id: image
         run: |
-          url=$(curl https://raw.githubusercontent.com/commaai/openpilot/master/system/hardware/tici/agnos.json | jq -r ".[] | select(.name == \"system\") | .url")
-          curl -L $url | unxz > system.img
+          meta=$(curl https://raw.githubusercontent.com/commaai/openpilot/master/system/hardware/tici/agnos.json | jq ".[] | select(.name == \"system\")")
+          echo hash=$(jq -r '.hash' <<< "$meta") >> $GITHUB_OUTPUT
+          echo url=$(jq -r '.url' <<< "$meta") >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v4
+        id: cache-system-image
+        with:
+          path: system.img.xz
+          key: system-image-${{ steps.image.outputs.hash }}
+
+      - name: download system image
+        if: steps.cache-system-image.outputs.cache-hit != 'true'
+        run: curl -L ${{ steps.image.outputs.url }} > system.img.xz
+
+      - name: unpack system image
+        run: cat system.img.xz | unxz > system.img
 
       - name: generate raw system image
         run: simg2img system.img system-raw.img

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
 
   benchmark:
     runs-on: ubuntu-24.04
-    timeout-minutes: 4
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
       - run: bun install
 
       - name: install sparse image tool
-        run: sudo apt-get update && sudo apt-get install -y simg2img
+        run: sudo apt-get update && sudo apt-get install -y android-sdk-libsparse-utils
 
       - name: download system image
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,24 +37,10 @@ jobs:
       - name: install sparse image tool
         run: sudo apt-get update && sudo apt-get install -y android-sdk-libsparse-utils
 
-      - id: image
-        run: |
-          meta=$(curl https://raw.githubusercontent.com/commaai/openpilot/master/system/hardware/tici/agnos.json | jq ".[] | select(.name == \"system\")")
-          echo hash=$(jq -r '.hash' <<< "$meta") >> $GITHUB_OUTPUT
-          echo url=$(jq -r '.url' <<< "$meta") >> $GITHUB_OUTPUT
-
-      - uses: actions/cache@v4
-        id: cache-system-image
-        with:
-          path: system.img.xz
-          key: system-image-${{ steps.image.outputs.hash }}
-
       - name: download system image
-        if: steps.cache-system-image.outputs.cache-hit != 'true'
-        run: curl -L ${{ steps.image.outputs.url }} > system.img.xz
-
-      - name: unpack system image
-        run: cat system.img.xz | unxz > system.img
+        run: |
+          url=$(curl https://raw.githubusercontent.com/commaai/openpilot/master/system/hardware/tici/agnos.json | jq -r ".[] | select(.name == \"system\") | .url")
+          curl -L $url | unxz > system.img
 
       - name: generate raw system image
         run: simg2img system.img system-raw.img

--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,5 @@ jspm_packages/
 
 # Finder (MacOS) folder config
 .DS_Store
+
+*.img

--- a/scripts/sparse-benchmark.js
+++ b/scripts/sparse-benchmark.js
@@ -1,0 +1,32 @@
+import * as Sparse from "../src/sparse";
+
+if (Bun.argv.length < 3) {
+  throw "Usage: bun sparse-benchmark.js <sparse.img> [expected-raw.img]";
+}
+
+const sparseImage = Bun.file(Bun.argv[2]);
+const expectedRawImage = Bun.argv[3] ? Bun.file(Bun.argv[3]) : null;
+
+let offset = 0;
+const startTime = performance.now();
+for await (const blob of Sparse.splitBlob(sparseImage)) {
+  if (expectedRawImage) {
+    const receivedChunkBuffer = Buffer.from(new Uint8Array(await blob.arrayBuffer()));
+    const [start, end] = [offset, offset + blob.size];
+    const expectedSlice = expectedRawImage.slice(start, end);
+    const expectedChunkBuffer = Buffer.from(new Uint8Array(await expectedSlice.arrayBuffer()));
+    const result = receivedChunkBuffer.compare(expectedChunkBuffer);
+    if (result) {
+      console.debug("Expected:", expectedChunkBuffer.toString("hex"));
+      console.debug("Received:", receivedChunkBuffer.toString("hex"));
+      throw `range ${start} to ${end} differs`;
+    }
+  }
+  offset += blob.size;
+}
+const endTime = performance.now();
+if (expectedRawImage && offset !== expectedRawImage.size) {
+  throw "size mismatch";
+}
+
+console.info(`Done in ${((endTime - startTime) / 1000).toFixed(3)}s`);


### PR DESCRIPTION
add a "benchmark" job, which is slow but doesn't block other jobs, to download the AGNOS system image and test sparse output is correct