### PR TITLE
support erase cmd

### DIFF
--- a/demo/src/index.html
+++ b/demo/src/index.html
@@ -19,7 +19,7 @@
         cursor: pointer;
         font-size: 16px;
         &:hover {
-          background: #0056b3;
+          filter: brightness(80%);
         }
       }
       #status {
@@ -83,6 +83,9 @@
       #partitions:before {
         content: "Partitions Information";
       }
+      #erase-button {
+        background: #d12000;
+      }
     </style>
   </head>
   <body>
@@ -111,6 +114,12 @@
         <option value="https://raw.githubusercontent.com/bkerler/Loaders/master/oneplus/0008b0e10051459b_dd7c5f2e53176bee_fhprg_op6t.bin">OnePlus 6T</option>
       </select>
       <button onclick="connectDevice()">Connect & Read Info</button>
+
+      <div class="erase-controls" style="display: none;">
+        <label for="partition-select">Select partition to erase:</label>
+        <select id="partition-select" style="margin-bottom: 8px;"></select>
+        <button id="erase-button" onclick="erasePartition()">Erase Partition</button>
+      </div>
     </section>
 
     <div id="status"></div>


### PR DESCRIPTION
- use `erase` command in firehose instead of writing `0x00`s to partition
  - the sdm845 programmer supports this command, maybe the sd821 didn't and that's why it wasn't discovered before
- doesn't immediately save time in Flash since we only explicitly erase the xbl partition! (maybe half a second)

This will be used by default. `firehose.cfg` isn't configurable yet but is left to a future contributor :slightly_smiling_face: 