### PR TITLE
refactor(usblib): don't sleep on write

### DIFF
--- a/src/firehose.js
+++ b/src/firehose.js
@@ -114,10 +114,9 @@ export class Firehose {
       SkipStorageInit: this.cfg.SkipStorageInit,
       SkipWrite: this.cfg.SkipWrite,
     });
-    // this is a hack, the loader receive the packet but doesn't respond back (same as edl repo)
     await this.xmlSend(connectCmd, false);
     await sleep(80);
-    this.luns = Array.from({ length: this.cfg.maxlun }, (x, i) => i);
+    this.luns = Array.from({length: this.cfg.maxlun}, (x, i) => i);
     return true;
   }
 

--- a/src/firehose.js
+++ b/src/firehose.js
@@ -58,12 +58,13 @@ export class Firehose {
 
   /**
    * @param {string} command
+   * @param {boolean} [wait=true]
    * @returns {Promise<response>}
    */
-  async xmlSend(command) {
+  async xmlSend(command, wait = true) {
     // FIXME: warn if command is shortened
     const dataToSend = new TextEncoder().encode(command).slice(0, this.cfg.MaxXMLSizeInBytes);
-    await this.cdc.write(dataToSend);
+    await this.cdc.write(dataToSend, wait);
 
     let rData = new Uint8Array();
     let counter = 0;
@@ -113,8 +114,8 @@ export class Firehose {
       SkipStorageInit: this.cfg.SkipStorageInit,
       SkipWrite: this.cfg.SkipWrite,
     });
-    await this.xmlSend(connectCmd);
     // this is a hack, the loader receive the packet but doesn't respond back (same as edl repo)
+    await this.xmlSend(connectCmd, false);
     await sleep(80);
     this.luns = Array.from({ length: this.cfg.maxlun }, (x, i) => i);
     return true;

--- a/src/usblib.js
+++ b/src/usblib.js
@@ -1,5 +1,5 @@
 import * as constants from "./constants";
-import { concatUint8Array, sleep } from "./utils";
+import { concatUint8Array } from "./utils";
 
 
 export class usbClass {

--- a/src/usblib.js
+++ b/src/usblib.js
@@ -115,27 +115,14 @@ export class usbClass {
 
   /**
    * @param {Uint8Array} data
-   * @param {boolean} [wait=true]
    * @returns {Promise<void>}
    */
-  async write(data, wait = true) {
-    if (data.byteLength === 0) {
-      try {
-        await this.device?.transferOut(this.epOut?.endpointNumber, data);
-      } catch {
-        await this.device?.transferOut(this.epOut?.endpointNumber, data);
-      }
-      return;
-    }
-
+  async write(data) {
     let offset = 0;
     do {
       const chunk = data.slice(offset, offset + constants.BULK_TRANSFER_SIZE);
       offset += chunk.byteLength;
-      const promise = this.device?.transferOut(this.epOut?.endpointNumber, chunk);
-      // this is a hack, webusb doesn't have timed out catching
-      // this only happens in sahara.configure(). The loader receive the packet but doesn't respond back (same as edl repo).
-      await (wait ? promise : sleep(80));
+      await this.device?.transferOut(this.epOut?.endpointNumber, chunk);
     } while (offset < data.byteLength);
   }
 }

--- a/src/usblib.js
+++ b/src/usblib.js
@@ -115,14 +115,16 @@ export class usbClass {
 
   /**
    * @param {Uint8Array} data
+   * @param {boolean} [wait=true]
    * @returns {Promise<void>}
    */
-  async write(data) {
+  async write(data, wait = true) {
     let offset = 0;
     do {
       const chunk = data.slice(offset, offset + constants.BULK_TRANSFER_SIZE);
       offset += chunk.byteLength;
-      await this.device?.transferOut(this.epOut?.endpointNumber, chunk);
+      const promise = this.device?.transferOut(this.epOut?.endpointNumber, chunk);
+      if (wait) await promise;
     } while (offset < data.byteLength);
   }
 }

--- a/src/usblib.js
+++ b/src/usblib.js
@@ -124,6 +124,8 @@ export class usbClass {
       const chunk = data.slice(offset, offset + constants.BULK_TRANSFER_SIZE);
       offset += chunk.byteLength;
       const promise = this.device?.transferOut(this.epOut?.endpointNumber, chunk);
+      // this is a hack, webusb doesn't have timed out catching
+      // this only happens in sahara.configure(). The loader receive the packet but doesn't respond back (same as edl repo).
       if (wait) await promise;
     } while (offset < data.byteLength);
   }


### PR DESCRIPTION
Simply sleep in firehose#configure where it's needed, this doesn't need to be part of the USBLib API