### PR TITLE
sparse: remove getSize method

### DIFF
--- a/src/firehose.js
+++ b/src/firehose.js
@@ -189,7 +189,7 @@ export class Firehose {
    * @param {number} physicalPartitionNumber
    * @param {number} startSector
    * @param {Blob} blob
-   * @param {progressCallback|undefined} [onProgress]
+   * @param {progressCallback|undefined} [onProgress] - Returns number of bytes written
    * @returns {Promise<boolean>}
    */
   async cmdProgram(physicalPartitionNumber, startSector, blob, onProgress = undefined) {
@@ -224,10 +224,11 @@ export class Firehose {
       bytesToWrite -= wlen;
 
       if (i % 10 === 0) {
-        onProgress?.(offset / total);
+        onProgress?.(offset);
       }
       i += 1;
     }
+    onProgress?.(total);
 
     const wd = await this.waitForData();
     const response = this.xml.getResponse(wd);
@@ -239,8 +240,6 @@ export class Firehose {
       console.error("Firehose - Failed to program: negative response");
       return false;
     }
-
-    onProgress?.(1.0);
     return true;
   }
 

--- a/src/qdl.js
+++ b/src/qdl.js
@@ -97,7 +97,7 @@ export class qdlDevice {
   /**
    * @param {string} partitionName
    * @param {Blob} blob
-   * @param {progressCallback} [onProgress]
+   * @param {progressCallback} [onProgress] - Returns number of bytes written
    * @returns {Promise<boolean>}
    */
   async flashBlob(partitionName, blob, onProgress) {
@@ -125,15 +125,13 @@ export class qdlDevice {
       console.error("qdl - Failed to erase partition before sparse flashing");
       return false;
     }
-    // TODO: get this from manifest/pass from caller
-    const totalSize = await sparse.getSize();
     console.debug(`Writing chunks to ${partitionName}...`);
     for await (const [offset, chunk] of sparse.read()) {
       if (offset % this.firehose.cfg.SECTOR_SIZE_IN_BYTES !== 0) {
         throw "qdl - Offset not aligned to sector size";
       }
       const sector = partition.sector + offset / this.firehose.cfg.SECTOR_SIZE_IN_BYTES;
-      const onChunkProgress = (progress) => onProgress?.(offset / totalSize + progress * chunk.size / totalSize);
+      const onChunkProgress = (progress) => onProgress?.(offset + progress);
       if (!await this.firehose.cmdProgram(lun, sector, chunk, onChunkProgress)) {
         console.debug("qdl - Failed to program chunk")
         return false;

--- a/src/qdl.js
+++ b/src/qdl.js
@@ -127,6 +127,7 @@ export class qdlDevice {
     }
     console.debug(`Writing chunks to ${partitionName}...`);
     for await (const [offset, chunk] of sparse.read()) {
+      if (!chunk) continue;
       if (offset % this.firehose.cfg.SECTOR_SIZE_IN_BYTES !== 0) {
         throw "qdl - Offset not aligned to sector size";
       }

--- a/src/sparse.spec.js
+++ b/src/sparse.spec.js
@@ -35,16 +35,13 @@ describe("sparse", () => {
       expect(chunks.length).toBe(sparse.header.totalChunks);
     });
 
-    test("getSize", async () => {
-      expect(await sparse.getSize()).toBe(sparse.header.totalBlocks * sparse.header.blockSize);
-    });
-
     test("read", async () => {
       let prevOffset = undefined;
-      for await (const [offset, chunk] of sparse.read()) {
+      for await (const [offset, chunk, size] of sparse.read()) {
         expect(offset).toBeGreaterThanOrEqual(prevOffset ?? 0);
-        expect(chunk.size).toBeGreaterThan(0);
-        prevOffset = offset + chunk.size;
+        if (chunk) expect(chunk.size).toBe(size);
+        expect(size).toBeGreaterThan(0);
+        prevOffset = offset + size;
       }
     });
   });


### PR DESCRIPTION
- sparse: remove getSize method
- qdldevice: flashBlob progress callback returns number of bytes

This allows for the re-writing Sparse as a TransformStream, where we don't need to read ahead to get the full size of the sparse image, for example.

Note: this is a breaking change, as the progress callback passed to `qdlDevice#flashBlob` will be called with the number of bytes instead of a number between 0 and 1.