### PR TITLE
HITL: cycle power for "QUSB" port

### DIFF
--- a/.github/workflows/hitl.yml
+++ b/.github/workflows/hitl.yml
@@ -23,9 +23,7 @@ jobs:
 
       - name: Power cycle USB ports
         run: |
-          uhubctl -l 1-1 -p 2 -a off
-          sleep 1
-          uhubctl -l 1-1 -p 2 -a on
+          sudo uhubctl -s QUSB -a cycle || sudo uhubctl -l 1-1 -a on
           sleep 1
 
       - run: qdl.js


### PR DESCRIPTION
uhubctl supports a "cycle" action and can filter by the device name. If the device isn't found we try to recover by turning on power to all ports on the default hub for the Pi.

I tried filtering by `-n 05c6` which I thought would be more reliable, but it didn't seem to work, maybe that's filtering the USB hub vendor instead