### PR TITLE
fix(firehose): wait longer for slow responses

### DIFF
--- a/src/firehose.js
+++ b/src/firehose.js
@@ -173,7 +173,7 @@ export class Firehose {
     let tmp = new Uint8Array();
     let timeout = 0;
     while (!containsBytes("<response", tmp)) {
-      const res = await runWithTimeout(this.cdc.read(), 150).catch(() => new Uint8Array());
+      const res = await runWithTimeout(this.cdc.read(), 1000).catch(() => new Uint8Array());
       if (compareStringToBytes("", res)) {
         timeout += 1;
         if (timeout > retries) break;


### PR DESCRIPTION
This doesn't affect the performance, it just allows the device more time to respond. The erase command seems to be slower, for example.

Bug introduced in #65 