### PR TITLE
feat: add device log message printing

### DIFF
--- a/src/firehose.js
+++ b/src/firehose.js
@@ -98,7 +98,9 @@ export class Firehose {
     if (!logs || !logs.length) return;
     for (const log of logs) {
       if (log.startsWith("ERROR:")) {
-        console.error(`[Device] ${log}`);
+        console.error(`[Device] ${log.substring(6).trim()}`);
+      } else if (log.startsWith("INFO:")) {
+        console.info(`[Device] ${log.substring(5).trim()}`);
       } else {
         console.info(`[Device] ${log}`);
       }


### PR DESCRIPTION
Add functionality to print log messages from the device using appropriate log levels:
- Log messages starting with "ERROR:" are printed with console.error
- All other log messages are printed with console.info
- All device logs are prefixed with "[Device]" for clarity
- Added log extraction and printing to multiple methods in the Firehose class