### PR TITLE
fix(flash): correct sector offset for sparse chunks

### DIFF
--- a/src/firehose.js
+++ b/src/firehose.js
@@ -212,9 +212,11 @@ export class Firehose {
   async cmdProgram(physicalPartitionNumber, startSector, blob, onProgress = undefined) {
     const total = blob.size;
 
+    const numPartitionSectors = Math.ceil(total / this.cfg.SECTOR_SIZE_IN_BYTES);
+    logger.debug(`Starting program on LUN ${physicalPartitionNumber} at ${startSector} - ${BigInt(startSector) + BigInt(numPartitionSectors - 1)} (${numPartitionSectors})`);
     const rsp = await this.xmlSend(toXml("program", {
       SECTOR_SIZE_IN_BYTES: this.cfg.SECTOR_SIZE_IN_BYTES,
-      num_partition_sectors: Math.ceil(total / this.cfg.SECTOR_SIZE_IN_BYTES),
+      num_partition_sectors: numPartitionSectors,
       physical_partition_number: physicalPartitionNumber,
       start_sector: startSector,
     }));

--- a/src/qdl.js
+++ b/src/qdl.js
@@ -283,7 +283,7 @@ export class qdlDevice {
       if (offset % gpt.sectorSize !== 0) {
         throw "qdl - Offset not aligned to sector size";
       }
-      const sector = (partition.start + BigInt(offset)) / BigInt(gpt.sectorSize);
+      const sector = partition.start + BigInt(offset / gpt.sectorSize);
       const onChunkProgress = (progress) => onProgress?.(offset + progress);
       if (!await this.firehose.cmdProgram(lun, sector, chunk, onChunkProgress)) {
         logger.debug("Failed to program chunk")


### PR DESCRIPTION
*Flashing* sparse images don't have any test coverage and we don't have a method to read back images from the device yet