### PR TITLE
feat: use `qdl.js` via `bunx`

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@commaai/qdl",
       "dependencies": {
-        "@incognitojam/tiny-struct": "npm:@jsr/incognitojam__tiny-struct@^0.1.2",
+        "@incognitojam/tiny-struct": "https://npm.jsr.io/~/11/@jsr/incognitojam__tiny-struct/0.1.2.tgz",
         "arg": "^5.0.2",
         "crc-32": "^1.2.2",
         "fast-xml-parser": "^5.0.8",
@@ -48,7 +48,7 @@
 
     "@happy-dom/global-registrator": ["@happy-dom/global-registrator@16.8.1", "", { "dependencies": { "happy-dom": "^16.8.1" } }, "sha512-EzV55rpNs5AXwFRb2tGrU6STr2Rgwtoi9awvh6vDglGZypXCFsJYYJpskZ2rhWaLL6Zbw5/+uJj+mocRPZuEUg=="],
 
-    "@incognitojam/tiny-struct": ["@jsr/incognitojam__tiny-struct@0.1.2", "https://npm.jsr.io/~/11/@jsr/incognitojam__tiny-struct/0.1.2.tgz", { "dependencies": { "type-fest": "^4.37.0" } }, "sha512-5cogSpBsKV1gTuvrX72tcx5CuG/Ddi0+RO0ldw76WavR6DD/suCjnmfuDzIuleSZD4UGHBR7njBssyorpqnVgw=="],
+    "@incognitojam/tiny-struct": ["@jsr/incognitojam__tiny-struct@https://npm.jsr.io/~/11/@jsr/incognitojam__tiny-struct/0.1.2.tgz", { "dependencies": { "type-fest": "^4.37.0" } }, "sha512-5cogSpBsKV1gTuvrX72tcx5CuG/Ddi0+RO0ldw76WavR6DD/suCjnmfuDzIuleSZD4UGHBR7njBssyorpqnVgw=="],
 
     "@types/bun": ["@types/bun@1.3.10", "", { "dependencies": { "bun-types": "1.3.10" } }, "sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ=="],
 

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "lint": "biome lint"
   },
   "bin": {
-    "simg2img.js": "dist/bin/simg2img.js",
-    "qdl.js": "dist/bin/qdl.js"
+    "simg2img.js": "src/bin/simg2img.js",
+    "qdl.js": "src/bin/qdl.js"
   },
   "//devDependencies": {
     "@biomejs/biome": "code linter and formatter",
@@ -52,7 +52,7 @@
     "usb": "node.js lib for communicating with USB devices, has WebUSB compatible API"
   },
   "dependencies": {
-    "@incognitojam/tiny-struct": "npm:@jsr/incognitojam__tiny-struct@^0.1.2",
+    "@incognitojam/tiny-struct": "https://npm.jsr.io/~/11/@jsr/incognitojam__tiny-struct/0.1.2.tgz",
     "arg": "^5.0.2",
     "crc-32": "^1.2.2",
     "fast-xml-parser": "^5.0.8",


### PR DESCRIPTION
## Summary
- Use JSR tarball URL for `@incognitojam/tiny-struct` instead of `npm:@jsr/...` which 404s on `registry.npmjs.org` when resolved via `bunx`
- Point `bin` entries to `src/` instead of `dist/` so `bunx` can run without a prior build step (bun runs JS source directly)

## Usage
```
bunx github:commaai/qdl.js getactiveslot
bunx github:commaai/qdl.js flash boot_a boot.img
```

## Validation
```
$ bunx "github:greatgitsby/qdl.js#d44a17b" --help
Resolving dependencies
Resolved, downloaded and extracted [15]
Saved lockfile
Usage: qdl.js <command> [...flags] [...args]

Commands:
  reset                                Reboot the device
  getactiveslot                        Get the active slot
  setactiveslot <slot>                 Set the active slot (a or b)
  getstorageinfo                       Print UFS information
  printgpt                             Print GPT luns and partitions
  repairgpt <lun> <image>              Repair GPT by flashing primary table and creating backup table
  erase <partition>                    Erase a partition
  flash <partition> <image>            Flash an image to a partition

$ bunx "github:greatgitsby/qdl.js#d44a17b" getactiveslot
a

$ bun test
 48 pass
 0 fail
 2 snapshots, 156 expect() calls
Ran 48 tests across 4 files. [457.00ms]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)