### PR TITLE
docs: add comma four USB vendor ID to udev rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,10 @@ After running the unbind command, verify no devices are bound to qcserial by run
 
 ### Desktop
 
-To fix USB permissions, create a file at `/etc/udev/rules.d/99-qualcomm-edl.rules` containing the following udev rule:
+To fix USB permissions, create a file at `/etc/udev/rules.d/99-qualcomm-edl.rules` containing the following udev rules:
 ```
 SUBSYSTEM=="usb", ATTR{idVendor}=="05c6", ATTR{idProduct}=="9008", MODE="0666"
+SUBSYSTEM=="usb", ATTR{idVendor}=="3801", ATTR{idProduct}=="9008", MODE="0666"
 ```
 
 For your udev rule changes to take effect, reboot or run:


### PR DESCRIPTION
## Summary
- Add udev rule for comma four's USB vendor ID (`3801`) alongside the existing Qualcomm one (`05c6`)
- Fix pluralization of "udev rule" -> "udev rules"

## Test plan
- [x] Verify comma four is accessible without root after adding the updated rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)