### PR TITLE
cli: add speed and ETA to progress bar

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -20,7 +20,7 @@ export const createQdl = async (programmerUrl = "https://raw.githubusercontent.c
   try {
     await qdl.connect(new usbClass());
   } catch (e) {
-    throw new Error("Failed to connect - missing udev rules?", { cause: e });
+    throw new Error(`Failed to connect: ${e.message || e}`, { cause: e });
   }
   return qdl;
 };
@@ -35,23 +35,40 @@ export const createQdl = async (programmerUrl = "https://raw.githubusercontent.c
  * @returns {(function(number): void)}
  */
 export const createProgress = (total = 1.0) => {
-  const terminalWidth = (process.stdout.columns || 80) - 7;
-  let prevChars = -1;
+  const barLength = 20;
   let finished = false;
+  let startTime = 0;
 
   return (progress) => {
+    if (startTime === 0) startTime = Date.now();
     if (progress <= 0) finished = false;
     if (finished) return;
 
+    const now = Date.now();
     const pct = Math.min(1, progress / total);
-    const chars = Math.floor(pct * terminalWidth);
-
-    if (chars === prevChars) return;
-    prevChars = chars;
-
-    const bar = "=".repeat(chars).padEnd(terminalWidth, " ");
+    const filledLength = Math.round(pct * barLength);
+    const bar = "\u2588".repeat(filledLength) + "-".repeat(barLength - filledLength);
     const percentStr = `${Math.round(pct * 100)}%`.padStart(4);
-    process.stderr.write(`\r\x1b[K[${bar}] ${percentStr}`);
+
+    // cumulative average throughput (MB/s)
+    const elapsed = (now - startTime) / 1000;
+    const throughput = elapsed > 0 ? progress / elapsed / 1024 / 1024 : 0;
+    // fixed-width: " 1234 MB/s" = 10 chars
+    const speedStr = `${Math.round(throughput).toString().padStart(5)} MB/s`;
+
+    // fixed-width time: "00h:00m:00s ____" = 16 chars
+    let timeStr = " ".repeat(16);
+    if (pct > 0 && elapsed > 0) {
+      const t = pct >= 1 ? elapsed : Math.max(0, (elapsed / pct) * (1 - pct));
+      const label = pct >= 1 ? "done" : "left";
+      const h = Math.floor(t / 3600);
+      const m = Math.floor((t % 3600) / 60);
+      const s = Math.floor(t % 60);
+      timeStr = `${String(h).padStart(2, "0")}h:${String(m).padStart(2, "0")}m:${String(s).padStart(2, "0")}s ${label}`;
+    }
+
+    const line = ` |${bar}| ${percentStr} ${speedStr} ${timeStr}`;
+    process.stderr.write(`\r${line}`);
 
     if (pct >= 1) {
       process.stderr.write("\n");


### PR DESCRIPTION
Matches the progress output style from the old edl Python tool.
- Fixed-width (20 char) progress bar instead of terminal-width expanding bar
- Shows MB/s throughput, updated on a rolling basis
- Shows estimated time remaining (e.g. `02m:30s left`)

```
 |████████████--------| 60.0% 45.23 MB/s 01m:30s left
```