### PR TITLE
increase USB bulk transfer size to 64KB

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,4 +1,4 @@
 export const VENDOR_IDS = [0x05C6, 0x3801];
 export const PRODUCT_ID = 0x9008;
 export const QDL_CLASS_CODE = 0xFF;
-export const BULK_TRANSFER_SIZE = 16384;
+export const BULK_TRANSFER_SIZE = 65536;


### PR DESCRIPTION
Flashing a 3.7GB sparse system image (`flash_system.sh`) on a comma four (`3801:9008`), 3 runs each:

| Transfer Size | Avg Time | Throughput |
|---|---|---|
| 16 KB (before) | 37.4s | 131 MB/s |
| **64 KB (after)** | **33.5s** | **148 MB/s** |
| 128 KB | 33.5s | 150 MB/s |
| 256 KB | 33.6s | 150 MB/s |